### PR TITLE
fix: sorting logic should be based on publishDateTime(xwalk) and publ…

### DIFF
--- a/blocks/side-navigation/side-navigation.js
+++ b/blocks/side-navigation/side-navigation.js
@@ -1,4 +1,4 @@
-import { formatDate } from '../../scripts/util.js';
+import { formatDate, sortDataByDate } from '../../scripts/util.js';
 
 export default async function decorate(block) {
   // Get all the main sections (divs) of the side-navigation
@@ -16,7 +16,7 @@ export default async function decorate(block) {
       sections[1].classList.add('posts');
 
       // Determine which JSON file to fetch based on URL
-      let jsonEndpoint = '/media-releases.json'; // Default
+      let jsonEndpoint = '/media-releases.json'; // Defaul
       const currentUrl = window.location.href.toLowerCase();
 
       if (currentUrl.includes('qantas-responds')) {
@@ -32,13 +32,8 @@ export default async function decorate(block) {
         const data = await response.json();
 
         // Get the top 3 entries by publishDateTime
-        const sortedEntries = data.data
+        const sortedEntries = sortDataByDate(data.data)
           .filter((entry) => entry.publisheddate || entry.publishDateTime)
-          .sort((a, b) => {
-            const dateA = new Date(a.publisheddate || a.publishDateTime);
-            const dateB = new Date(b.publisheddate || b.publishDateTime);
-            return dateB - dateA;
-          })
           .slice(0, 3); // Take top 3 after sorting
 
         // Create a container for the entries
@@ -57,22 +52,18 @@ export default async function decorate(block) {
           linkElement.textContent = entry.title;
           titleElement.appendChild(linkElement);
 
-          // Create date element
           const dateElement = document.createElement('p');
           dateElement.className = 'date';
           const publishedLocation = entry.publishedlocation ? `${entry.publishedlocation} • ` : '';
           const formattedDate = formatDate(entry.publisheddate || entry.publishDateTime);
           dateElement.textContent = publishedLocation + formattedDate;
 
-          // Add elements to entry
           entryElement.appendChild(titleElement);
           entryElement.appendChild(dateElement);
 
-          // Add entry to container
           entriesContainer.appendChild(entryElement);
         });
 
-        // Clear existing content
         sections[1].innerHTML = '';
         sections[1].appendChild(entriesContainer);
       } catch (error) {

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -14,24 +14,52 @@ export function getOrdinalSuffix(day) {
 }
 
 /**
+ * Normalizes ISO date strings to ensure they have valid format with leading zeros
+ * @param {string} dateString - The date string to normalize
+ * @return {string} - Normalized date string
+ */
+export function normalizeISODateString(dateString) {
+  if (!dateString) return '';
+
+  // Handle case where hour doesn't have leading zero (T9: instead of T09:)
+  if (dateString.match(/T\d:/)) {
+    // Find position of T and insert a 0 after it if needed
+    const tPos = dateString.indexOf('T');
+    if (tPos > 0) {
+      return `${dateString.substring(0, tPos + 1)}0${dateString.substring(tPos + 1)}`;
+    }
+  }
+  return dateString;
+}
+
+/**
+ * Sorts data by date in descending order (newest first)
+ * @param {Array} data - Array of objects containing date fields
+ * @param {string} [dateField1='publisheddate'] - Primary date field name
+ * @param {string} [dateField2='publishDateTime'] - Secondary date field name
+ * @return {Array} - Sorted array
+ */
+export function sortDataByDate(data, dateField1 = 'publisheddate', dateField2 = 'publishDateTime') {
+  if (!data || !Array.isArray(data)) return [];
+
+  return [...data].sort((a, b) => {
+    const dateA = new Date(normalizeISODateString(a[dateField1] || a[dateField2]));
+    const dateB = new Date(normalizeISODateString(b[dateField1] || b[dateField2]));
+    return dateB - dateA; // Sort in descending order (newest first)
+  });
+}
+
+/**
  * Internal helper function for date formatting
- * @param {string} dateString - The date string to forma
- * @param {boolean} includeTime - Whether to include time in the outpu
+ * @param {string} dateString - The date string to format
+ * @param {boolean} includeTime - Whether to include time in the output
  * @return {string} - Formatted date string
  */
 function formatDateInternal(dateString, includeTime) {
   if (!dateString) return '';
 
-  // Normalize the date string format if needed
-  // Handle case where hour doesn't have leading zero (8:30 instead of 08:30)
-  let normalizedDateString = dateString;
-  if (dateString.match(/T\d:/)) {
-    // Find position of T and insert a 0 after it if needed
-    const tPos = dateString.indexOf('T');
-    if (tPos > 0) {
-      normalizedDateString = `${dateString.substring(0, tPos + 1)}0${dateString.substring(tPos + 1)}`;
-    }
-  }
+  // Normalize the date string format using the utility function
+  const normalizedDateString = normalizeISODateString(dateString);
 
   const date = new Date(normalizedDateString);
   if (Number.isNaN(date.getTime())) {
@@ -69,7 +97,7 @@ function formatDateInternal(dateString, includeTime) {
 
 /**
  * Format date from ISO string to readable format "9th March 2025 at 9:00"
- * @param {string} dateString - The date string to forma
+ * @param {string} dateString - The date string to format
  * @return {string} - Formatted date string
  */
 export function formatDate(dateString) {
@@ -78,7 +106,7 @@ export function formatDate(dateString) {
 
 /**
  * Format date from ISO string to readable format without time "9th March 2025"
- * @param {string} dateString - The date string to forma
+ * @param {string} dateString - The date string to format
  * @return {string} - Formatted date string without time
  */
 export function formatDateNoTime(dateString) {


### PR DESCRIPTION
…isheddate(old-content)

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #66 

Test URLs:
- Before: https://main--xwalk-qantas--aemdemos.aem.live/
- After: https://issue-66--xwalk-qantas--aemdemos.aem.live/speeches0
- After: https://issue-66--xwalk-qantas--aemdemos.aem.live/media-releases/
- After: https://issue-66--xwalk-qantas--aemdemos.aem.live/roo-tales/
- After: https://issue-66--xwalk-qantas--aemdemos.aem.live/qantas-responds/
