### PR TITLE
fix: Generate correct topic links for speeches pages

### DIFF
--- a/blocks/side-navigation/side-navigation.js
+++ b/blocks/side-navigation/side-navigation.js
@@ -36,7 +36,7 @@ function getQueryIndexJsonEndpoint() {
 function getTopicLink(topic) {
   const currentUrl = window.location.href.toLowerCase();
   let topicLink = window.location.origin;
-  if (currentUrl.includes('/media-releases/')) {
+  if (currentUrl.includes('/media-releases/') || currentUrl.includes('/speeches/')) {
     topicLink += `/topic?tag=${topic}`;
   } else if (currentUrl.includes(('/roo-tales/'))) {
     topicLink += `/roo-tales-topic?tag=${topic}`;

--- a/blocks/side-navigation/side-navigation.js
+++ b/blocks/side-navigation/side-navigation.js
@@ -36,7 +36,8 @@ function getQueryIndexJsonEndpoint() {
 function getTopicLink(topic) {
   const currentUrl = window.location.href.toLowerCase();
   let topicLink = window.location.origin;
-  if (currentUrl.includes('/media-releases/') || currentUrl.includes('/speeches/')) {
+  if (currentUrl.includes('/media-releases/') || currentUrl.includes('/speeches/')
+    || currentUrl.includes('/qantas-responds/') || currentUrl.includes('/featured/')) {
     topicLink += `/topic?tag=${topic}`;
   } else if (currentUrl.includes(('/roo-tales/'))) {
     topicLink += `/roo-tales-topic?tag=${topic}`;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #139 

Test URLs:
- Before: https://www.qantasnewsroom.com.au/speeches/qantas-airways-ltd-half-year-results-alan-joyce-qantas-ceo-speech/
- After: https://issues-139--xwalk-qantas--aemdemos.aem.page/speeches/qantas-airways-ltd-half-year-results-alan-joyce-qantas-ceo-speech
