### PR TITLE
Alignment broken for page https://main--xwalk-qantas--aemdemos.aem.page/uncategorized/qantas-gala-dinner-photos

### DIFF
--- a/blocks/side-navigation/side-navigation.js
+++ b/blocks/side-navigation/side-navigation.js
@@ -37,7 +37,8 @@ function getTopicLink(topic) {
   const currentUrl = window.location.href.toLowerCase();
   let topicLink = window.location.origin;
   if (currentUrl.includes('/media-releases/') || currentUrl.includes('/speeches/')
-    || currentUrl.includes('/qantas-responds/') || currentUrl.includes('/featured/')) {
+    || currentUrl.includes('/qantas-responds/') || currentUrl.includes('/featured/')
+    || currentUrl.includes('/uncategorized/')) {
     topicLink += `/topic?tag=${topic}`;
   } else if (currentUrl.includes(('/roo-tales/'))) {
     topicLink += `/roo-tales-topic?tag=${topic}`;

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -17,6 +17,7 @@ indices:
   news:
     include:
       - '/media-releases/*'
+      - '/uncategorized/*'
     exclude:
       - '/**.json'
     target: /media-releases.json

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -17,7 +17,6 @@ indices:
   news:
     include:
       - '/media-releases/*'
-      - '/uncategorized/*'
     exclude:
       - '/**.json'
     target: /media-releases.json
@@ -87,6 +86,7 @@ indices:
     include:
       - '/qantas-responds/*'
       - '/featured/*'
+      - '/uncategorized/*'
     exclude:
       - '/**.json'
     target: /qantas-responds.json

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -69,6 +69,7 @@ async function decorateTemplates(main) {
       '/roo-tales/',
       '/speeches/',
       '/media-releases/',
+      '/uncategorized/',
     ];
 
     // Get the current pathname


### PR DESCRIPTION
fix: Apply article template, side navigation, and JSON indexing to uncategorized pages.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #142 

Test URLs:
- Before: https://main--xwalk-qantas--aemdemos.aem.live/uncategorized/qantas-gala-dinner-photos
- After: https://issue-142--xwalk-qantas--aemdemos.aem.live/uncategorized/qantas-gala-dinner-photos
